### PR TITLE
Throttle Alerts

### DIFF
--- a/app/airq/models/clients.py
+++ b/app/airq/models/clients.py
@@ -329,7 +329,12 @@ class Client(db.Model):  # type: ignore
         # Do not alert clients who received an alert recently unless AQI has changed markedly.
         was_alerted_recently = self.last_alert_sent_at > timestamp() - (60 * 60 * 6)
         last_aqi = self.last_aqi
-        if was_alerted_recently and last_aqi and abs(curr_aqi - last_aqi) < 20:
+        if (
+            was_alerted_recently
+            and last_aqi
+            and curr_aqi
+            and abs(curr_aqi - last_aqi) < 20
+        ):
             return False
 
         message = (

--- a/app/airq/models/clients.py
+++ b/app/airq/models/clients.py
@@ -316,6 +316,11 @@ class Client(db.Model):  # type: ignore
         if curr_aqi_level == last_aqi_level:
             return False
 
+        # Do not alert clients who received an alert recently unless AQI has changed markedly.
+        was_alerted_recently = self.last_alert_sent_at and self.last_alert_sent_at > timestamp() - (60 * 60 * 6)
+        if was_alerted_recently and abs(curr_aqi - last_aqi) < 20:
+            return False
+
         message = (
             "Air quality in {city} {zipcode} has changed to {curr_aqi_level} (AQI {curr_aqi}).\n"
             "\n"

--- a/app/airq/models/zipcodes.py
+++ b/app/airq/models/zipcodes.py
@@ -64,6 +64,10 @@ class Zipcode(db.Model):  # type: ignore
         return "".join([getattr(self, f"geohash_bit_{i}") for i in range(1, 13)])
 
     @property
+    def aqi(self) -> typing.Optional[int]:
+        return pm25_to_aqi(self.pm25)
+
+    @property
     def pm25_level(self) -> Pm25:
         return Pm25.from_measurement(self.pm25)
 


### PR DESCRIPTION
Throttle alerts such that:
* If the AQI changes categories and we haven't sent you an alert in the last 6 hours, we alert you.
* If the AQI changes categories and we haven't sent you an alert in the last 2 hours, but the change is more than 20 points, we alert you.

Otherwise, we do not send the alert.